### PR TITLE
Trigger checks workflow on any push in any branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,6 @@
-name: Check commits in non-main branches
+name: Check commits in all branches (including main)
 
-on:
-  push:
-    branches-ignore:
-      - main
+on: push
 
 jobs:
   checks:


### PR DESCRIPTION
This is alright because pushing to `main` will not automatically trigger a release.

Publishing of packages will only happen when a new "release" has been created manually from GitHub UI.