### PR TITLE
Callback to receive raw response body from featurevisor data request

### DIFF
--- a/src/main/kotlin/com/featurevisor/sdk/Instance+Refresh.kt
+++ b/src/main/kotlin/com/featurevisor/sdk/Instance+Refresh.kt
@@ -42,6 +42,7 @@ private fun FeaturevisorInstance.refresh() {
             fetchDatafileContent(
                 datafileUrl,
                 handleDatafileFetch,
+                rawResponseReady,
             ) { result ->
 
                 if (result.isSuccess) {

--- a/src/main/kotlin/com/featurevisor/sdk/Instance.kt
+++ b/src/main/kotlin/com/featurevisor/sdk/Instance.kt
@@ -9,6 +9,7 @@ import com.featurevisor.types.EventName.*
 import kotlinx.coroutines.Job
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import okhttp3.ResponseBody
 
 typealias ConfigureBucketKey = (Feature, Context, BucketKey) -> BucketKey
 typealias ConfigureBucketValue = (Feature, Context, BucketValue) -> BucketValue
@@ -56,6 +57,7 @@ class FeaturevisorInstance private constructor(options: InstanceOptions) {
     internal var configureBucketKey = options.configureBucketKey
     internal var configureBucketValue = options.configureBucketValue
     internal var refreshJob: Job? = null
+    internal var rawResponseReady: (ResponseBody) -> Unit = options.rawResponseReady
 
     init {
         with(options) {
@@ -100,7 +102,7 @@ class FeaturevisorInstance private constructor(options: InstanceOptions) {
 
                 datafileUrl != null -> {
                     datafileReader = DatafileReader(options.datafile?: emptyDatafile)
-                    fetchDatafileContent(datafileUrl, handleDatafileFetch) { result ->
+                    fetchDatafileContent(datafileUrl, handleDatafileFetch, rawResponseReady) { result ->
                         if (result.isSuccess) {
                             datafileReader = DatafileReader(result.getOrThrow())
                             statuses.ready = true

--- a/src/main/kotlin/com/featurevisor/sdk/InstanceOptions.kt
+++ b/src/main/kotlin/com/featurevisor/sdk/InstanceOptions.kt
@@ -3,6 +3,7 @@ package com.featurevisor.sdk
 import com.featurevisor.types.DatafileContent
 import com.featurevisor.types.InitialFeatures
 import com.featurevisor.types.StickyFeatures
+import okhttp3.ResponseBody
 
 typealias Listener = (Array<out Any>) -> Unit
 
@@ -23,6 +24,7 @@ data class InstanceOptions(
     val onError: Listener? = null,
     val refreshInterval: Long? = null, // seconds
     val stickyFeatures: StickyFeatures? = null,
+    val rawResponseReady: (ResponseBody) -> Unit = {},
 ) {
     companion object {
         private const val defaultBucketKeySeparator = "."


### PR DESCRIPTION
Added callback to receive Json data from request response. It is possible to use FetchDataHandler to receive it also, but it requires implementing whole request preparation,execution and response handling. Doing it that way will hide the code responsible for setting FeaturevisorInstance states.
Now we could receive the Json response without duplicating the code inside app that uses SDK.