### PR TITLE
Json type variable parsing issue fixes

### DIFF
--- a/src/main/kotlin/com/featurevisor/sdk/Instance+Evaluation.kt
+++ b/src/main/kotlin/com/featurevisor/sdk/Instance+Evaluation.kt
@@ -475,7 +475,7 @@ fun FeaturevisorInstance.evaluateVariable(
 
         // initial
         if (!statuses.ready && initialFeatures?.get(featureKey)?.variables?.get(variableKey) != null) {
-            val variableValue = initialFeatures?.get(featureKey)?.variables?.get(variableKey)
+            val variableValue = initialFeatures[featureKey]?.variables?.get(variableKey)
             evaluation = Evaluation(
                 featureKey = featureKey,
                 reason = INITIAL,

--- a/src/main/kotlin/com/featurevisor/sdk/Instance+Variable.kt
+++ b/src/main/kotlin/com/featurevisor/sdk/Instance+Variable.kt
@@ -84,7 +84,7 @@ inline fun <reified T : Any> FeaturevisorInstance.getVariableObject(
     }
 }
 
-inline fun <reified T : Any> FeaturevisorInstance.getVariableJSON(
+inline fun <reified T> FeaturevisorInstance.getVariableJSON(
     featureKey: FeatureKey,
     variableKey: VariableKey,
     context: Context,


### PR DESCRIPTION
Fixed: **getVariableJson()** unable to parse value for complex data types passed as Generic Type Parameter.