### PR TITLE
Added missing environment in benchmarking

### DIFF
--- a/src/main/kotlin/com/featurevisor/testRunner/BenchmarkFeature.kt
+++ b/src/main/kotlin/com/featurevisor/testRunner/BenchmarkFeature.kt
@@ -28,7 +28,7 @@ fun benchmarkFeature(option: BenchMarkOptions) {
 
     val datafileBuildStart = System.nanoTime().toDouble()
 
-    val datafileContent = buildDataFileAsPerEnvironment(option.projectRootPath,"staging")
+    val datafileContent = buildDataFileAsPerEnvironment(option.projectRootPath, option.environment)
 
     val datafileBuildEnd = System.nanoTime().toDouble()
 


### PR DESCRIPTION
While benchmarking `option.environment` is missing and it is always running for staging which is hardcoded. In this PR hardcoded environment is removed and now we are taking environment from `option.environment`